### PR TITLE
move files to asdf install path

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,6 +21,7 @@ set -e
   mkdir -p "$ASDF_INSTALL_PATH/bin" &&
     cd "$ASDF_DOWNLOAD_PATH/src/github.com/mongodb/mongo-tools" &&
     GOBIN="$ASDF_INSTALL_PATH/bin" GOROOT=$GOROOT ./build.sh ssl sasl &&
+    mv "${ASDF_DOWNLOAD_PATH}"/src/github.com/mongodb/mongo-tools/bin/* "${ASDF_INSTALL_PATH}/bin/" &&
     echo "mongo-tools have been installed." &&
     rm -rf "$ASDF_DOWNLOAD_PATH"
 ) || (


### PR DESCRIPTION
It appears that the `GOBIN` variable is not being used as a location to output the binaries, as I expected it woud be when reading the code. Simply moving the built binaries into place works.

Fixes #1 